### PR TITLE
Manage size of barcode within jsbarcode options rather than JPEG size

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       <br>
       <a href="javascript:pdfexport();">Exportar PDF</a>
       <!-- jspdf cdn -->
-      <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/barcodes/JsBarcode.code39.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/1.5.3/jspdf.debug.js"></script>
       <script type="text/javascript" src="script.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -33,11 +33,13 @@ function pdfexport(){
 
     JsBarcode("#code39", inmod, {
         format: 'CODE39',
-        displayValue: false
+        displayValue: false,
+        height: 28,
+        margin: 0
     });
     const img = document.querySelector('img#code39');
     doc.setFontSize(10);
-    doc.addImage(img.src, 'JPEG', 33, 22, 65, 7);
+    doc.addImage(img.src, 'JPEG', 35, 22);
 
     doc.text("Importador", 10, 34);
     doc.text("PV Comunicaciones S.A de C.V", 35, 34);


### PR DESCRIPTION
This fixes the blur effect that we had on the barcode

Also updated to only use `code39` instead of _all_ barcodes.

✌🏼 